### PR TITLE
Handle pagination

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,4 +38,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-issues-finder/action:0.0.1'
+  image: 'docker://ghcr.io/paritytech/stale-issues-finder/action:0.0.2'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-issues-finder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Find what issues have been stale for a given time",
   "main": "src/index.ts",
   "engines": {

--- a/src/github/issuesParser.ts
+++ b/src/github/issuesParser.ts
@@ -2,12 +2,29 @@ import { debug } from "@actions/core";
 import { GitHub } from "@actions/github/lib/utils";
 import moment from "moment";
 
+//** Handles the problem of pagination */
+const getAllIssues = async (octokit: InstanceType<typeof GitHub>, repo: Repo): Promise<IssueData[]> => {
+    const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, state: "open" });
+    let issues = data;
+    if (issues.length > 99) {
+        let fullPage = issues.length > 99;
+        let currentPage = 2;
+        while (fullPage) {
+            const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, page: currentPage, state: "open" });
+            issues = issues.concat(data);
+            fullPage = data.length > 99;
+            currentPage++;
+        }
+    }
+    return issues;
+}
+
 export const fetchIssues = async (octokit: InstanceType<typeof GitHub>, repo: Repo): Promise<IssueData[]> => {
-    const issues = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, state: "open" });
-    debug(`Found elements ${issues.data.length}`);
+    const issues = await getAllIssues(octokit, repo);
+    debug(`Found elements ${issues.length}`);
 
     // order them from stalest to most recent
-    const orderedDates = issues.data.sort((a, b) => {
+    const orderedDates = issues.sort((a, b) => {
         return b.updated_at > a.updated_at ? -1 : b.updated_at < a.updated_at ? 1 : 0
     });
 

--- a/src/github/issuesParser.ts
+++ b/src/github/issuesParser.ts
@@ -7,15 +7,13 @@ const getAllIssues = async (octokit: InstanceType<typeof GitHub>, repo: Repo): P
     let currentPage = 1;
     const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, state: "open", page: currentPage });
     let issues = data;
-    if (issues.length > 99) {
-        let fullPage = issues.length > 99;
-        while (fullPage) {
-            currentPage++;
-            debug(`Iterating on page ${currentPage} with ${issues.length} issues`);
-            const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, page: currentPage, state: "open" });
-            issues = issues.concat(data);
-            fullPage = data.length > 99;
-        }
+    let fullPage = issues.length > 99;
+    while (fullPage) {
+        currentPage++;
+        debug(`Iterating on page ${currentPage} with ${issues.length} issues`);
+        const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, page: currentPage, state: "open" });
+        issues = issues.concat(data);
+        fullPage = data.length > 99;
     }
 
     debug(`Found a total of ${issues.length} issues`);

--- a/src/github/issuesParser.ts
+++ b/src/github/issuesParser.ts
@@ -2,16 +2,21 @@ import { debug } from "@actions/core";
 import { GitHub } from "@actions/github/lib/utils";
 import moment from "moment";
 
+const listForRepo = (octokit: InstanceType<typeof GitHub>, repo: Repo, per_page: number = 100, page: number = 1) => {
+    return octokit.rest.issues.listForRepo({ ...repo, per_page, state: "open", page });
+}
+
 //** Handles the problem of pagination */
 const getAllIssues = async (octokit: InstanceType<typeof GitHub>, repo: Repo): Promise<IssueData[]> => {
+    const perPage = 100;
     let currentPage = 1;
-    const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, state: "open", page: currentPage });
+    const { data } = await listForRepo(octokit, repo, perPage, currentPage);
     let issues = data;
     let fullPage = issues.length > 99;
     while (fullPage) {
         currentPage++;
         debug(`Iterating on page ${currentPage} with ${issues.length} issues`);
-        const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, page: currentPage, state: "open" });
+        const { data } = await listForRepo(octokit, repo, perPage, currentPage)
         issues = issues.concat(data);
         fullPage = data.length > 99;
     }

--- a/src/github/issuesParser.ts
+++ b/src/github/issuesParser.ts
@@ -4,18 +4,21 @@ import moment from "moment";
 
 //** Handles the problem of pagination */
 const getAllIssues = async (octokit: InstanceType<typeof GitHub>, repo: Repo): Promise<IssueData[]> => {
-    const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, state: "open" });
+    let currentPage = 1;
+    const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, state: "open", page: currentPage });
     let issues = data;
     if (issues.length > 99) {
         let fullPage = issues.length > 99;
-        let currentPage = 2;
         while (fullPage) {
+            currentPage++;
+            debug(`Iterating on page ${currentPage} with ${issues.length} issues`);
             const { data } = await octokit.rest.issues.listForRepo({ ...repo, per_page: 100, page: currentPage, state: "open" });
             issues = issues.concat(data);
             fullPage = data.length > 99;
-            currentPage++;
         }
     }
+
+    debug(`Found a total of ${issues.length} issues`);
     return issues;
 }
 


### PR DESCRIPTION
Added the ability to iterate over pages.

Resolves #4

The logic is quite simple. It fetches items from a page. If there are more than 99 elements, then that page is full and it goes over to the next page.

Upgraded version to `0.0.2` to have a new release