### PR TITLE
added support for list-team-members

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ You can find all the inputs in [the action file](./action.yml) but let's walk th
 - `ignoreAuthors`: Array of usernames that, if an issue was created by them, will be ignored.
   - Short for `Ignore issues coming from these authors`.
   - **optional**
-  - **Important**: If set, be sure to read the [Warning about authors field](#warning-about-authors-field) section.
+  - **Important**: If set be sure to connect the names by comma.
+    - Example: `username1,username2,user3`
+    - It is **not** _case sensitive_.
+  - It works great in conjuction with [`paritytech/list-team-members`](https://github.com/paritytech/list-team-members)
+    - It can use the output directly to ignore any issues made by a member of a team.
 
 #### Accessing other repositories
 
@@ -77,30 +81,6 @@ The action has the ability to access other repositories but if it can read it or
 
 The default `${{ github.token }}` variable has enough permissions to read the issues in **public repositories**.
 If you want this action to access to the issues in a private repository, then you will need a `Personal Access Token` with `repo` permissions.
-
-### Warning about authors field
-The authors field accepts an array or a single value, [but only with some particular format](https://github.com/actions/toolkit/issues/184#issuecomment-1198653452), so it is important to follow it.
-It accepts either:
-```yml
-ignoreAuthors: username1
-```
-or an array of authors using a `pipe`:
-```yml
-ignoreAuthors: |
-  username1
-  username2
-  username3
-```
-It **does not** support the following type of arrays:
-```yml
-# not this one
-ignoreAuthors:
-  - username1
-  - username2
-
-# also doesn't support this one
-ignoreAuthors: ["username1", "username2"]
-```
 
 ### Outputs
 Outputs are needed for your chained actions. If you want to use this information, remember to set an `id` field in the step so you can access it.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can find all the inputs in [the action file](./action.yml) but let's walk th
 - `noComments`: Boolean. If the action should only fetch issues that have 0 comments.
   - Short for `Ignore issues that have comments`.
   - **default**: false
-- `ignoreAuthors`: Array of usernames that, if an issue was created by them, will be ignored.
+- `ignoreAuthors`: Collections of usernames separated by commas that, if an issue was created by any of them, will be ignored.
   - Short for `Ignore issues coming from these authors`.
   - **optional**
   - **Important**: If set be sure to connect the names by comma.

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: false
   ignoreAuthors:
     required: false
-    description: array of usernames that should be ignored if they are the author of the issue.
+    description: collections of usernames separated by commas that should be ignored if they are the author of the issue.
     type: string
 outputs:
   repo:

--- a/action.yml
+++ b/action.yml
@@ -38,4 +38,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-issues-finder/action:0.0.2'
+  image: 'docker://ghcr.io/paritytech/stale-issues-finder/action:0.0.3'

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     default: false
   ignoreAuthors:
     required: false
-    description: collections of usernames separated by commas that should be ignored if they are the author of the issue.
+    description: Collections of usernames separated by commas that should be ignored if they are the author of the issue.
     type: string
 outputs:
   repo:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-issues-finder",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Find what issues have been stale for a given time",
   "main": "src/index.ts",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getBooleanInput, getInput, getMultilineInput, info, setOutput, summary } from "@actions/core";
+import { getBooleanInput, getInput, info, setOutput, summary } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 import { Context } from "@actions/github/lib/context";
 import moment from "moment";
@@ -15,7 +15,11 @@ const getFiltersFromInput = (): Filters => {
 
     const noComments = !!getInput("noComments") ? getBooleanInput("noComments") : false;
 
-    const ignoreAuthors = getMultilineInput("ignoreAuthors");
+    let ignoreAuthors: string[] = [];
+    const authorsToIgnore = getInput("ignoreAuthors");
+    if (authorsToIgnore) {
+        ignoreAuthors = authorsToIgnore.split(",");
+    }
 
     return {
         daysStale, noComments, notFromAuthor: ignoreAuthors


### PR DESCRIPTION
Improved system so it works in pair with [`paritytech/list-team-members`](https://github.com/paritytech/list-team-members).

Instead of using the confusing pipe system now it is an array of comma separated values.