### PR TITLE
Fixed filter order execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,4 +38,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-issues-finder/action:0.0.3'
+  image: 'docker://ghcr.io/paritytech/stale-issues-finder/action:0.0.4'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-issues-finder",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Find what issues have been stale for a given time",
   "main": "src/index.ts",
   "engines": {


### PR DESCRIPTION
Fixed the moment where the results are filtered.

Before we assumed that if we had stale issues, that was a positive result and then we would execute the filters.

With this change we execute filters BEFORE we take the happy path, solving us from the issue of reporting 5 issues but not showing anything in the data.

I also removed the summary from the event that there are no stale issues as it was over population the summary page