### PR TITLE
Removed PRs from summaries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,4 +38,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/stale-issues-finder/action:0.0.5'
+  image: 'docker://ghcr.io/paritytech/stale-issues-finder/action:0.0.6'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-issues-finder",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Find what issues have been stale for a given time",
   "main": "src/index.ts",
   "engines": {

--- a/src/github/issuesParser.ts
+++ b/src/github/issuesParser.ts
@@ -11,7 +11,9 @@ const getAllIssues = async (octokit: InstanceType<typeof GitHub>, repo: Repo): P
     const perPage = 100;
     let currentPage = 1;
     const { data } = await listForRepo(octokit, repo, perPage, currentPage);
-    let issues = data;
+
+    // GitHub's REST API v3 considers every pull request an issue so we need to get objects without the PR key
+    let issues = data.filter(data => !data.pull_request);
     let fullPage = issues.length > 99;
     while (fullPage) {
         currentPage++;


### PR DESCRIPTION
From the documentation:
> GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by the pull_request key. Be aware that the id of a pull request returned from "Issues" endpoints will be an issue id.

This commit filters objects that *have* a `pull_request` object